### PR TITLE
DEVPROD-36192: Wire a content-hash cache key into FindAndTranslateProjectForVersion

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -620,10 +620,21 @@ func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 	// stored with the ID.
 	pp.Identifier = utility.ToStringPtr(v.Identifier)
 
-	// The cache is disabled, so this key is only used to coalesce concurrent translations of the same
-	// version. Before enabling the cache, switch to a content-derived key (contentTranslationKey),
-	// because a version ID would keep serving a stale config after generate.tasks rewrites the project.
-	key := versionTranslationKey(v.Id, preGeneration)
+	var key string
+	if translationCacheEnabled {
+		var sha string
+		sha, err = parserProjectContentSHA(pp)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "computing parser project content hash")
+		}
+		key = contentTranslationKey(sha, v.Identifier)
+	} else {
+		// When the cache is off, we don't need a key that changes whenever the parser project changes
+		// (which the LRU requires so it never serves a stale config after generate.tasks). We can instead
+		// use the version ID. It's cheaper and enough for singleflight, which only coalesces concurrent
+		// in-flight calls and retains nothing that could go stale.
+		key = versionTranslationKey(v.Id, preGeneration)
+	}
 	p, cacheHit, err := getOrComputeTranslation(key, translationCacheEnabled, func() (*Project, error) {
 		return TranslateProject(pp)
 	})

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -1,12 +1,16 @@
 package model
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -83,4 +87,15 @@ func contentTranslationKey(contentsSHA, identifier string) string {
 // fileTranslationKey is the self-invalidating LRU key for the LoadProjectInto / GetProjectFromFile path.
 func fileTranslationKey(projectID, revision, contentsSHA string) string {
 	return fmt.Sprintf("f:%s:%s:%s", projectID, revision, contentsSHA)
+}
+
+// parserProjectContentSHA returns the hex-encoded SHA-256 of pp marshaled as JSON.
+// Must be called after pp.Identifier is set so the identifier is included in the hash.
+func parserProjectContentSHA(pp *ParserProject) (string, error) {
+	data, err := json.Marshal(pp)
+	if err != nil {
+		return "", errors.Wrap(err, "marshaling parser project")
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
 }

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -271,4 +272,101 @@ func TestTranslationKeysAreDistinctAndStable(t *testing.T) {
 	// Keys are deterministic for identical inputs.
 	assert.Equal(t, contentTranslationKey("s", "i"), contentTranslationKey("s", "i"))
 	assert.Equal(t, fileTranslationKey("p", "r", "s"), fileTranslationKey("p", "r", "s"))
+}
+
+func TestParserProjectContentSHA(t *testing.T) {
+	t.Run("StableAcrossRepeatedCalls", func(t *testing.T) {
+		pp := &ParserProject{
+			Identifier: utility.ToStringPtr("my-project"),
+			Functions: map[string]*YAMLCommandSet{
+				"fn1": {SingleCommand: &PluginCommandConf{Command: "shell.exec"}},
+				"fn2": {SingleCommand: &PluginCommandConf{Command: "s3.put"}},
+			},
+		}
+		sha1, err := parserProjectContentSHA(pp)
+		require.NoError(t, err)
+		sha2, err := parserProjectContentSHA(pp)
+		require.NoError(t, err)
+		assert.Equal(t, sha1, sha2, "same struct must hash identically on every call")
+	})
+
+	t.Run("StableAcrossMapInsertionOrder", func(t *testing.T) {
+		// encoding/json sorts map keys, so two maps with the same entries produce the same
+		// hash regardless of which order the keys were inserted.
+		cmd1 := &PluginCommandConf{Command: "shell.exec"}
+		cmd2 := &PluginCommandConf{Command: "s3.put"}
+		pp1 := &ParserProject{
+			Functions: map[string]*YAMLCommandSet{
+				"alpha": {SingleCommand: cmd1},
+				"beta":  {SingleCommand: cmd2},
+			},
+		}
+		pp2 := &ParserProject{
+			Functions: map[string]*YAMLCommandSet{
+				"beta":  {SingleCommand: cmd2},
+				"alpha": {SingleCommand: cmd1},
+			},
+		}
+		sha1, err := parserProjectContentSHA(pp1)
+		require.NoError(t, err)
+		sha2, err := parserProjectContentSHA(pp2)
+		require.NoError(t, err)
+		assert.Equal(t, sha1, sha2, "map insertion order must not affect the hash")
+	})
+
+	t.Run("SensitiveToFieldChanges", func(t *testing.T) {
+		pp := &ParserProject{Identifier: utility.ToStringPtr("project-a")}
+		sha1, err := parserProjectContentSHA(pp)
+		require.NoError(t, err)
+		pp.Identifier = utility.ToStringPtr("project-b")
+		sha2, err := parserProjectContentSHA(pp)
+		require.NoError(t, err)
+		assert.NotEqual(t, sha1, sha2, "changed field must produce a different hash")
+	})
+}
+
+// TestParserProjectContentSHASelfInvalidation verifies that content-hash keying gives a cache hit
+// for unchanged content and a miss after content changes, with no invalidation call.
+func TestParserProjectContentSHASelfInvalidation(t *testing.T) {
+	t.Cleanup(resetTranslationCacheForTesting)
+
+	identifier := "my-project"
+
+	pp := &ParserProject{
+		Identifier: utility.ToStringPtr(identifier),
+		Tasks:      []parserTask{{Name: "original-task"}},
+	}
+	sha, err := parserProjectContentSHA(pp)
+	require.NoError(t, err)
+	key := contentTranslationKey(sha, identifier)
+
+	_, hit, err := getOrComputeTranslation(key, true, func() (*Project, error) {
+		return &Project{Identifier: identifier, Tasks: []ProjectTask{{Name: "original-task"}}}, nil
+	})
+	require.NoError(t, err)
+	assert.False(t, hit, "first call is a cache miss")
+
+	_, hit, err = getOrComputeTranslation(key, true, func() (*Project, error) {
+		t.Fatal("compute must not be called on a cache hit")
+		return nil, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, hit, "unchanged content key is a cache hit")
+
+	// Simulate generate.tasks: changed content → different hash → new key → miss, no invalidation.
+	ppGenerated := &ParserProject{
+		Identifier: utility.ToStringPtr(identifier),
+		Tasks:      []parserTask{{Name: "original-task"}, {Name: "generated-task"}},
+	}
+	shaGenerated, err := parserProjectContentSHA(ppGenerated)
+	require.NoError(t, err)
+	require.NotEqual(t, sha, shaGenerated, "new content must produce a different hash")
+	keyGenerated := contentTranslationKey(shaGenerated, identifier)
+
+	pGenerated, hit, err := getOrComputeTranslation(keyGenerated, true, func() (*Project, error) {
+		return &Project{Identifier: identifier, Tasks: []ProjectTask{{Name: "original-task"}, {Name: "generated-task"}}}, nil
+	})
+	require.NoError(t, err)
+	assert.False(t, hit, "changed content produces a new key that is a cache miss")
+	require.Len(t, pGenerated.Tasks, 2)
 }


### PR DESCRIPTION
DEVPROD-36192

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

This wires the content-hash-based translation key into`FindAndTranslateProjectForVersion`. Later, once we set`translationCacheEnabled` to true, the key will be derived from a SHA-256 hash of the marshaled`ParserProject`rather than the version ID. That way, a changed parser project after `generate.tasks`automatically produces a new key, so the LRU never serves a stale config.

The cache flag is still `false`, so there is no change in production.

Note: I'm using stacked PRs for the first time so hopefully nothing weird happens. 

<!--add description, context, thought process, etc-->

### Testing

Added tests.

<!--Remember to add or edit docs in the docs/ directory if relevant.-->

<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->